### PR TITLE
Fix for Supporting CoAP NON confirmable messages

### DIFF
--- a/coap.cpp
+++ b/coap.cpp
@@ -251,8 +251,8 @@ bool Coap::loop() {
 
         } else {
             
-            // call endpoint url function
             String url = "";
+            // call endpoint url function
             for (int i = 0; i < packet.optionnum; i++) {
                 if (packet.options[i].number == COAP_URI_PATH && packet.options[i].length > 0) {
                     char urlname[packet.options[i].length + 1];
@@ -262,23 +262,15 @@ bool Coap::loop() {
                       url += "/";
                     url += urlname;
                 }
-            }
-        }
+            }        
 
-        if (packet.type == COAP_CON) {
-#if defined(ARDUINO)
-            if (!uri.find(url)) {
-#elif defined(SPARK)
-            if (uri.find(url) == uri.end()) {
-#endif
-                sendResponse(_udp->remoteIP(), _udp->remotePort(), packet.messageid, NULL, 0,
-                        COAP_NOT_FOUNT, COAP_NONE, NULL, 0);
-            } else {
-#if defined(ARDUINO)
-                uri.find(url)(packet, _udp->remoteIP(), _udp->remotePort());
-#elif defined(SPARK)
-                uri[url](packet, _udp->remoteIP(), _udp->remotePort());
-#endif
+            if (packet.type == COAP_CON) {
+                if (!uri.find(url)) {
+                    sendResponse(_udp->remoteIP(), _udp->remotePort(), packet.messageid, NULL, 0,
+                            COAP_NOT_FOUNT, COAP_NONE, NULL, 0);
+                } else {
+                    uri.find(url)(packet, _udp->remoteIP(), _udp->remotePort());
+                }
             }
         }
 

--- a/coap.cpp
+++ b/coap.cpp
@@ -249,7 +249,8 @@ bool Coap::loop() {
             // call response function
             resp(packet, _udp->remoteIP(), _udp->remotePort());
 
-        } else if (packet.type == COAP_CON) {
+        } else {
+            
             // call endpoint url function
             String url = "";
             for (int i = 0; i < packet.optionnum; i++) {
@@ -260,8 +261,11 @@ bool Coap::loop() {
                     if(url.length() > 0)
                       url += "/";
                     url += urlname;
-                  }
+                }
             }
+        }
+
+        if (packet.type == COAP_CON) {
 #if defined(ARDUINO)
             if (!uri.find(url)) {
 #elif defined(SPARK)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=CoAP simple library
-version=1.3.7
+name=SPZ CoAP simple library
+version=1.3.8
 author=Hirotaka Niisato <hirotakaster@gmail.com>
 maintainer=Hirotaka Niisato <hirotakaster@gmail.com>
 sentence=Simple CoAP client/server library for generic Arduino Client hardware.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=SPZ CoAP simple library
-version=1.3.8
+name=CoAP simple library
+version=1.3.7
 author=Hirotaka Niisato <hirotakaster@gmail.com>
 maintainer=Hirotaka Niisato <hirotakaster@gmail.com>
 sentence=Simple CoAP client/server library for generic Arduino Client hardware.


### PR DESCRIPTION
non confirmable file do not call the callback function and falls unhandled, this fix provides supports for CoAP non confirmable messages, calling the callback and unhanding the response message. Suggest to add back the SPARK support cause I didn't need it.

Hope it would be useful.

Greetings