### PR TITLE
Automatic confirmable response support added

### DIFF
--- a/coap.cpp
+++ b/coap.cpp
@@ -264,14 +264,18 @@ bool Coap::loop() {
                 }
             }        
 
-            if (packet.type == COAP_CON) {
-                if (!uri.find(url)) {
-                    sendResponse(_udp->remoteIP(), _udp->remotePort(), packet.messageid, NULL, 0,
-                            COAP_NOT_FOUNT, COAP_NONE, NULL, 0);
-                } else {
-                    uri.find(url)(packet, _udp->remoteIP(), _udp->remotePort());
-                }
+            if (!uri.find(url)) {
+                sendResponse(_udp->remoteIP(), _udp->remotePort(), packet.messageid, NULL, 0,
+                        COAP_NOT_FOUNT, COAP_NONE, NULL, 0);
+            } else {
+                uri.find(url)(packet, _udp->remoteIP(), _udp->remotePort());
             }
+        }
+
+        if (packet.type == COAP_CON) {
+            // send response 
+            sendResponse(_udp->remoteIP(), _udp->remotePort(), packet.messageid);
+
         }
 
         // next packet


### PR DESCRIPTION
Hi,  i made a slightly new update, supporting automatic handling of confirmable coap requests. Now the response to the client is sent autonomously by the server, without need to be implemented into the server's callaback logic.