### PR TITLE
Use std::function in stead of function pointer for callback

### DIFF
--- a/coap.h
+++ b/coap.h
@@ -23,6 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef __SIMPLE_COAP_H__
 #define __SIMPLE_COAP_H__
 
+#include <functional>
 #include "Udp.h"
 #define MAX_CALLBACK 10
 
@@ -121,7 +122,7 @@ class CoapPacket {
     uint8_t optionnum;
     CoapOption options[MAX_OPTION_NUM];
 };
-typedef void (*callback)(CoapPacket &, IPAddress, int);
+typedef std::function<void(CoapPacket &, IPAddress, int)> callback;
 
 class CoapUri {
     private:


### PR DESCRIPTION
This change facilitates much easier integration of CoAP-simple-library with C++ code: in stead of using a C function pointer callbacks are specified using a std::function. This seems common practice nowadays (see for example the esp8266 HTTP Server). By using a std::function it becomes possible to specify instance methods as the callbacks without having to go through C helper functions.

The change should be API-compatible with the original code.