### PR TITLE
Add possibility to specify content-format in send()

### DIFF
--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -3,6 +3,14 @@
 
 #define LOGGING
 
+void CoapPacket::addOption(uint8_t number, uint8_t length, uint8_t *opt_payload)
+{
+    options[optionnum].number = number;
+    options[optionnum].length = length;
+    options[optionnum].buffer = opt_payload;
+
+    ++optionnum;
+}
 
 Coap::Coap(
     UDP& udp
@@ -127,28 +135,19 @@ uint16_t Coap::send(IPAddress ip, int port, char *url, COAP_TYPE type, COAP_METH
 
     // use URI_HOST UIR_PATH
     String ipaddress = String(ip[0]) + String(".") + String(ip[1]) + String(".") + String(ip[2]) + String(".") + String(ip[3]); 
-    packet.options[packet.optionnum].buffer = (uint8_t *)ipaddress.c_str();
-    packet.options[packet.optionnum].length = ipaddress.length();
-    packet.options[packet.optionnum].number = COAP_URI_HOST;
-    packet.optionnum++;
+	packet.addOption(COAP_URI_HOST, ipaddress.length(), (uint8_t *)ipaddress.c_str());
 
     // parse url
     int idx = 0;
     for (int i = 0; i < strlen(url); i++) {
         if (url[i] == '/') {
-            packet.options[packet.optionnum].buffer = (uint8_t *)(url + idx);
-            packet.options[packet.optionnum].length = i - idx;
-            packet.options[packet.optionnum].number = COAP_URI_PATH;
-            packet.optionnum++;
+			packet.addOption(COAP_URI_PATH, i-idx, (uint8_t *)(url + idx));
             idx = i + 1;
         }
     }
 
     if (idx <= strlen(url)) {
-        packet.options[packet.optionnum].buffer = (uint8_t *)(url + idx);
-        packet.options[packet.optionnum].length = strlen(url) - idx;
-        packet.options[packet.optionnum].number = COAP_URI_PATH;
-        packet.optionnum++;
+		packet.addOption(COAP_URI_PATH, strlen(url)-idx, (uint8_t *)(url + idx));
     }
 
     // send packet
@@ -324,10 +323,7 @@ uint16_t Coap::sendResponse(IPAddress ip, int port, uint16_t messageid, char *pa
     char optionBuffer[2];
     optionBuffer[0] = ((uint16_t)type & 0xFF00) >> 8;
     optionBuffer[1] = ((uint16_t)type & 0x00FF) ;
-    packet.options[packet.optionnum].buffer = (uint8_t *)optionBuffer;
-    packet.options[packet.optionnum].length = 2;
-    packet.options[packet.optionnum].number = COAP_CONTENT_FORMAT;
-    packet.optionnum++;
+	packet.addOption(COAP_CONTENT_FORMAT, 2, (uint8_t *)optionBuffer);
 
     return this->sendPacket(packet, ip, port);
 }

--- a/coap-simple.h
+++ b/coap-simple.h
@@ -186,6 +186,7 @@ class Coap {
         uint16_t put(IPAddress ip, int port, char *url, char *payload);
         uint16_t put(IPAddress ip, int port, char *url, char *payload, int payloadlen);
         uint16_t send(IPAddress ip, int port, char *url, COAP_TYPE type, COAP_METHOD method, uint8_t *token, uint8_t tokenlen, uint8_t *payload, uint32_t payloadlen);
+        uint16_t send(IPAddress ip, int port, char *url, COAP_TYPE type, COAP_METHOD method, uint8_t *token, uint8_t tokenlen, uint8_t *payload, uint32_t payloadlen, COAP_CONTENT_TYPE content_type);
 
         bool loop();
 };

--- a/coap-simple.h
+++ b/coap-simple.h
@@ -98,7 +98,8 @@ typedef enum {
     COAP_APPLICATION_XML = 41,
     COAP_APPLICATION_OCTET_STREAM = 42,
     COAP_APPLICATION_EXI = 47,
-    COAP_APPLICATION_JSON = 50
+    COAP_APPLICATION_JSON = 50,
+    COAP_APPLICATION_CBOR = 60
 } COAP_CONTENT_TYPE;
 
 class CoapOption {
@@ -110,16 +111,18 @@ class CoapOption {
 
 class CoapPacket {
     public:
-    uint8_t type;
-    uint8_t code;
-    uint8_t *token;
-    uint8_t tokenlen;
-    uint8_t *payload;
-    uint8_t payloadlen;
-    uint16_t messageid;
-    
-    uint8_t optionnum;
-    CoapOption options[MAX_OPTION_NUM];
+		uint8_t type;
+		uint8_t code;
+		uint8_t *token;
+		uint8_t tokenlen;
+		uint8_t *payload;
+		uint8_t payloadlen;
+		uint16_t messageid;
+		
+		uint8_t optionnum;
+		CoapOption options[MAX_OPTION_NUM];
+
+		void addOption(uint8_t number, uint8_t length, uint8_t *opt_payload);
 };
 typedef void (*callback)(CoapPacket &, IPAddress, int);
 


### PR DESCRIPTION
This contains two commits:
- First one (2bc27da) add a method in `CoapPacket`, that allows to easily add an option (saving some lines of codes, overall).
- Second one (4ecc153) add an overloaded `send()` method for `Coap`, allowing to specify a content-format (just like `sendResponse()`).

Btw, in 2bc27da, I also added a `COAP_CONTENT_TYPE` for `CBOR`.