### PR TITLE
Convert IPaddress to string using a char array instead of a String

### DIFF
--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -138,8 +138,9 @@ uint16_t Coap::send(IPAddress ip, int port, char *url, COAP_TYPE type, COAP_METH
     packet.messageid = rand();
 
     // use URI_HOST UIR_PATH
-    String ipaddress = String(ip[0]) + String(".") + String(ip[1]) + String(".") + String(ip[2]) + String(".") + String(ip[3]); 
-	packet.addOption(COAP_URI_HOST, ipaddress.length(), (uint8_t *)ipaddress.c_str());
+	char ipaddress[16] = "";
+	sprintf(ipaddress, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	packet.addOption(COAP_URI_HOST, strlen(ipaddress), (uint8_t *)ipaddress);
 
     // parse url
     int idx = 0;

--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -138,9 +138,9 @@ uint16_t Coap::send(IPAddress ip, int port, char *url, COAP_TYPE type, COAP_METH
     packet.messageid = rand();
 
     // use URI_HOST UIR_PATH
-	char ipaddress[16] = "";
-	sprintf(ipaddress, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-	packet.addOption(COAP_URI_HOST, strlen(ipaddress), (uint8_t *)ipaddress);
+    char ipaddress[16] = "";
+    sprintf(ipaddress, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+    packet.addOption(COAP_URI_HOST, strlen(ipaddress), (uint8_t *)ipaddress);
 
     // parse url
     int idx = 0;


### PR DESCRIPTION
Any IPv4 address can be represented as a string between 16 (15 + '\0') and 8 (7 + '\0') characters :
* 1.1.1.1 -> 7 + 1 characters.
* 255.255.255.255 -> 15 + 1 characters.

Memory fragmentation due to String allocation can cause crash or undefined behaviors in microcontrollers. This is especially true for very constrained device like the atmega328p in the Arduino Uno.

This PR address this issue by changing the type of `ipaddress` to `char[16]`, allowing for static memory allocation.
int -> string conversion is then handled by `sprintf()`.