### PR TITLE
Fixes to help integrating CoAP-simple-library in other projects

### DIFF
--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -115,15 +115,15 @@ uint16_t Coap::put(IPAddress ip, int port, const char *url, const char *payload)
     return this->send(ip, port, url, COAP_CON, COAP_PUT, NULL, 0, (uint8_t *)payload, strlen(payload));
 }
 
-uint16_t Coap::put(IPAddress ip, int port, const char *url, const char *payload, int payloadlen) {
+uint16_t Coap::put(IPAddress ip, int port, const char *url, const char *payload, size_t payloadlen) {
     return this->send(ip, port, url, COAP_CON, COAP_PUT, NULL, 0, (uint8_t *)payload, payloadlen);
 }
 
-uint16_t Coap::send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, uint32_t payloadlen) {
+uint16_t Coap::send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, size_t payloadlen) {
     return this->send(ip, port, url, type, method, token, tokenlen, payload, payloadlen, COAP_NONE);
 }
 
-uint16_t Coap::send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, uint32_t payloadlen, COAP_CONTENT_TYPE content_type) {
+uint16_t Coap::send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, size_t payloadlen, COAP_CONTENT_TYPE content_type) {
 
     // make packet
     CoapPacket packet;
@@ -313,12 +313,12 @@ uint16_t Coap::sendResponse(IPAddress ip, int port, uint16_t messageid, const ch
     return this->sendResponse(ip, port, messageid, payload, strlen(payload), COAP_CONTENT, COAP_TEXT_PLAIN, NULL, 0);
 }
 
-uint16_t Coap::sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, int payloadlen) {
+uint16_t Coap::sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, size_t payloadlen) {
     return this->sendResponse(ip, port, messageid, payload, payloadlen, COAP_CONTENT, COAP_TEXT_PLAIN, NULL, 0);
 }
 
 
-uint16_t Coap::sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, int payloadlen,
+uint16_t Coap::sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, size_t payloadlen,
                 COAP_RESPONSE_CODE code, COAP_CONTENT_TYPE type, const uint8_t *token, int tokenlen) {
     // make packet
     CoapPacket packet;

--- a/coap-simple.h
+++ b/coap-simple.h
@@ -123,7 +123,7 @@ class CoapPacket {
 		const uint8_t *token = NULL;
 		uint8_t tokenlen = 0;
 		const uint8_t *payload = NULL;
-		uint8_t payloadlen = 0;
+		size_t payloadlen = 0;
 		uint16_t messageid = 0;
 		uint8_t optionnum = 0;
 		CoapOption options[COAP_MAX_OPTION_NUM];
@@ -185,14 +185,14 @@ class Coap {
         void server(CoapCallback c, String url) { uri.add(c, url); }
         uint16_t sendResponse(IPAddress ip, int port, uint16_t messageid);
         uint16_t sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload);
-        uint16_t sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, int payloadlen);
-        uint16_t sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, int payloadlen, COAP_RESPONSE_CODE code, COAP_CONTENT_TYPE type, const uint8_t *token, int tokenlen);
+        uint16_t sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, size_t payloadlen);
+        uint16_t sendResponse(IPAddress ip, int port, uint16_t messageid, const char *payload, size_t payloadlen, COAP_RESPONSE_CODE code, COAP_CONTENT_TYPE type, const uint8_t *token, int tokenlen);
         
         uint16_t get(IPAddress ip, int port, const char *url);
         uint16_t put(IPAddress ip, int port, const char *url, const char *payload);
-        uint16_t put(IPAddress ip, int port, const char *url, const char *payload, int payloadlen);
-        uint16_t send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, uint32_t payloadlen);
-        uint16_t send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, uint32_t payloadlen, COAP_CONTENT_TYPE content_type);
+        uint16_t put(IPAddress ip, int port, const char *url, const char *payload, size_t payloadlen);
+        uint16_t send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, size_t payloadlen);
+        uint16_t send(IPAddress ip, int port, const char *url, COAP_TYPE type, COAP_METHOD method, const uint8_t *token, uint8_t tokenlen, const uint8_t *payload, size_t payloadlen, COAP_CONTENT_TYPE content_type);
 
         bool loop();
 };

--- a/coap-simple.h
+++ b/coap-simple.h
@@ -23,6 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef __SIMPLE_COAP_H__
 #define __SIMPLE_COAP_H__
 
+#include <functional>
 #include "Udp.h"
 #define MAX_CALLBACK 10
 
@@ -123,7 +124,7 @@ class CoapPacket {
 
 		void addOption(uint8_t number, uint8_t length, uint8_t *opt_payload);
 };
-typedef void (*callback)(CoapPacket &, IPAddress, int);
+typedef std::function<void(CoapPacket &, IPAddress, int)> callback;
 
 class CoapUri {
     private:

--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+    "name" : "CoAP simple library",
+    "version" : "1.3.18",
+    "description" : "Simple CoAP client/server library for generic Arduino Client hardware.",
+    "keywords" : "communication, coap, wifi",
+    "authors" : {
+        "name" : "Hirotaka Niisato",
+        "email" : "hirotakaster@gmail.com"
+    },
+    "repository" : {
+        "type" : "git",
+        "url" : "https://github.com/hirotakaster/CoAP-simple-library"
+    },
+    "frameworks" : "Arduino",
+    "examples" : [
+        "[Ee]xamples/*/*.ino"
+    ]
+}


### PR DESCRIPTION
This pull request contains one bug fix:

- payloadlen was uint8_t in packet declaration, so packets could never have a payload bigger than 255 bytes. Changed to size_t everywhere.

In addition there are a number of fixes to help using this module in other packages:

- Type `callback` changed to `CoapCallback` so it does not conflict with identifiers used in other packages.
- Various defined size constants prefixed with `COAP_` so they don't conflict, and made overridable using compiler flags.
- Use a `std::function` in stead of a function pointer for callbacks. This makes integration with C++ methods a lot easier (and should be backward compatible).
- Added a `library.json` to enable easy use of this package in _platformio_