### PR TITLE
Made the library compatible with stock Arduino

### DIFF
--- a/coap-simple.h
+++ b/coap-simple.h
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define COAP_MAX_OPTION_NUM 10
 #endif
 #ifndef COAP_BUF_MAX_SIZE
-#define COAP_BUF_MAX_SIZE 1024
+#define COAP_BUF_MAX_SIZE 128
 #endif
 #define COAP_DEFAULT_PORT 5683
 
@@ -129,7 +129,6 @@ class CoapPacket {
 
 		void addOption(uint8_t number, uint8_t length, uint8_t *opt_payload);
 };
-
 typedef void (*CoapCallback)(CoapPacket &, IPAddress, int);
 
 class CoapUri {

--- a/coap-simple.h
+++ b/coap-simple.h
@@ -23,7 +23,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef __SIMPLE_COAP_H__
 #define __SIMPLE_COAP_H__
 
-#include <functional>
 #include "Udp.h"
 #ifndef COAP_MAX_CALLBACK
 #define COAP_MAX_CALLBACK 10
@@ -130,7 +129,8 @@ class CoapPacket {
 
 		void addOption(uint8_t number, uint8_t length, uint8_t *opt_payload);
 };
-typedef std::function<void(CoapPacket &, IPAddress, int)> CoapCallback;
+
+typedef void (*CoapCallback)(CoapPacket &, IPAddress, int);
 
 class CoapUri {
     private:


### PR DESCRIPTION
This pull request does two things:

1. We revert the implementation of CoapCallback to use function pointers because Arduino doesn't have access to the C++ 11 standard template library (so can't use `typedef std::function<void(CoapPacket &, IPAddress, int)> CoapCallback;`)

2. We reduce the maximum size of the COAP buffer so it works out-of-the-box with the Arduino Uno. I've changed it to 128, but you can get away with 256 (or potentially even 512) - but this doesn't leave you much space to play with on the Arduino Uno.

Regards,

Alex