### PR TITLE
Arduino 3.1 apparently requires const cast when appending a char * to a string.

### DIFF
--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -279,7 +279,7 @@ bool Coap::loop() {
                     urlname[packet.options[i].length] = 0;
                     if(url.length() > 0)
                       url += "/";
-                    url += urlname;
+                    url += (const char *)urlname;
                 }
             }
 


### PR DESCRIPTION
This micro-fix addresses that.

Platformio builds again with this fix. Arduino however doesn't build, but it fails with errors in the Arduino Ethernet module. I have the feeling this may have to do with Arduino trying to build with Arduino 3.0 and it containing errors that have been fixed in the Arduino 3.1 that platformio uses. Not sure though.