### PR TITLE
Fix -Wsign-compare warnings

### DIFF
--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -147,8 +147,8 @@ uint16_t Coap::send(IPAddress ip, int port, const char *url, COAP_TYPE type, COA
     packet.addOption(COAP_URI_HOST, strlen(ipaddress), (uint8_t *)ipaddress);
 
     // parse url
-    int idx = 0;
-    for (int i = 0; i < strlen(url); i++) {
+    size_t idx = 0;
+    for (size_t i = 0; i < strlen(url); i++) {
         if (url[i] == '/') {
 			packet.addOption(COAP_URI_PATH, i-idx, (uint8_t *)(url + idx));
             idx = i + 1;


### PR DESCRIPTION
strlen() returns size_t, so adjust variables i and idx to size_t as well

Fixes warnings:
```
coap-simple.cpp:151:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < strlen(url); i++) {
                     ~~^~~~~~~~~~~~~
coap-simple.cpp:158:13: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (idx <= strlen(url)) {
         ~~~~^~~~~~~~~~~~~~
```
Found by enabling all compiler warnings.