### PR TITLE
Add unit tests and mock implementations for coap-simple library

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,25 @@
+# Host-side unit tests for the coap-simple library.
+# Compiles the library against a mocked Arduino environment (test/mocks) and a
+# FakeUDP transport, then runs the test suite. Runs on PRs to master so every
+# change is exercised before merge.
+name: unit-tests
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y g++ make
+
+      - name: Build and run unit tests
+        working-directory: test
+        run: make test

--- a/coap-simple.cpp
+++ b/coap-simple.cpp
@@ -155,7 +155,7 @@ uint16_t Coap::sendPacket(CoapPacket &packet, IPAddress ip, int port)
     // make payload
     if (packet.payloadlen > 0)
     {
-        if ((packetSize + 1 + packet.payloadlen) >= coap_buf_size)
+        if ((packetSize + 1 + packet.payloadlen) >= (size_t)coap_buf_size)
         {
             return 0;
         }
@@ -213,7 +213,7 @@ uint16_t Coap::send(IPAddress ip, int port, const char *url, COAP_TYPE type, COA
 
     // use URI_HOST UIR_PATH
     char ipaddress[16] = "";
-    sprintf(ipaddress, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+    snprintf(ipaddress, sizeof(ipaddress), "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
     packet.addOption(COAP_URI_HOST, strlen(ipaddress), (uint8_t *)ipaddress);
 
     /*
@@ -410,7 +410,8 @@ bool Coap::loop()
             {
                 if (packet.options[i].number == COAP_URI_PATH && packet.options[i].length > 0)
                 {
-                    char urlname[packet.options[i].length + 1];
+                    // option length is a uint8_t, so 256 bytes always suffices.
+                    char urlname[256];
                     memcpy(urlname, packet.options[i].buffer, packet.options[i].length);
                     urlname[packet.options[i].length] = 0;
                     if (url.length() > 0)

--- a/coap-simple.h
+++ b/coap-simple.h
@@ -242,7 +242,6 @@ private:
     UDP *_udp;
     CoapUri uri;
     CoapCallback resp;
-    int _port;
     int coap_buf_size;
     uint8_t *tx_buffer = NULL;
     uint8_t *rx_buffer = NULL;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,3 @@
+runner
+runner.dSYM/
+*.o

--- a/test/CoapCodec.h
+++ b/test/CoapCodec.h
@@ -1,0 +1,248 @@
+// Small CoAP encode/decode helpers used only by the tests, so assertions can
+// be written against decoded packet fields instead of raw byte offsets.
+#ifndef __COAP_CODEC_H__
+#define __COAP_CODEC_H__
+
+#include <cstdint>
+#include <vector>
+#include <string>
+
+struct DecodedOption
+{
+    uint16_t number;
+    std::vector<uint8_t> value;
+
+    std::string str() const { return std::string(value.begin(), value.end()); }
+};
+
+struct DecodedPacket
+{
+    bool valid = false;
+    uint8_t version = 0;
+    uint8_t type = 0;
+    uint8_t tokenlen = 0;
+    uint8_t code = 0;
+    uint16_t messageid = 0;
+    std::vector<uint8_t> token;
+    std::vector<DecodedOption> options;
+    std::vector<uint8_t> payload;
+
+    std::string payloadStr() const { return std::string(payload.begin(), payload.end()); }
+
+    // Returns the first option with the given number, or nullptr.
+    const DecodedOption *option(uint16_t number) const
+    {
+        for (const auto &o : options)
+            if (o.number == number)
+                return &o;
+        return nullptr;
+    }
+
+    int optionCount(uint16_t number) const
+    {
+        int n = 0;
+        for (const auto &o : options)
+            if (o.number == number)
+                n++;
+        return n;
+    }
+
+    std::string optionString(uint16_t number) const
+    {
+        const DecodedOption *o = option(number);
+        if (!o)
+            return "";
+        return std::string(o->value.begin(), o->value.end());
+    }
+};
+
+// Decode a raw CoAP datagram. On any malformed input, valid stays false.
+inline DecodedPacket coapDecode(const std::vector<uint8_t> &buf)
+{
+    DecodedPacket p;
+    if (buf.size() < 4)
+        return p;
+
+    p.version = (buf[0] & 0xC0) >> 6;
+    p.type = (buf[0] & 0x30) >> 4;
+    p.tokenlen = buf[0] & 0x0F;
+    p.code = buf[1];
+    p.messageid = ((uint16_t)buf[2] << 8) | buf[3];
+
+    size_t pos = 4;
+    if (p.tokenlen > 8 || pos + p.tokenlen > buf.size())
+        return p;
+    for (uint8_t i = 0; i < p.tokenlen; i++)
+        p.token.push_back(buf[pos++]);
+
+    uint16_t running = 0;
+    while (pos < buf.size() && buf[pos] != 0xFF)
+    {
+        uint8_t b = buf[pos++];
+        uint16_t delta = (b & 0xF0) >> 4;
+        uint16_t len = b & 0x0F;
+
+        if (delta == 13)
+        {
+            if (pos >= buf.size())
+                return p;
+            delta = buf[pos++] + 13;
+        }
+        else if (delta == 14)
+        {
+            if (pos + 1 >= buf.size())
+                return p;
+            delta = ((buf[pos] << 8) | buf[pos + 1]) + 269;
+            pos += 2;
+        }
+
+        if (len == 13)
+        {
+            if (pos >= buf.size())
+                return p;
+            len = buf[pos++] + 13;
+        }
+        else if (len == 14)
+        {
+            if (pos + 1 >= buf.size())
+                return p;
+            len = ((buf[pos] << 8) | buf[pos + 1]) + 269;
+            pos += 2;
+        }
+
+        if (pos + len > buf.size())
+            return p;
+
+        DecodedOption opt;
+        opt.number = running + delta;
+        for (uint16_t i = 0; i < len; i++)
+            opt.value.push_back(buf[pos++]);
+        running = opt.number;
+        p.options.push_back(opt);
+    }
+
+    if (pos < buf.size() && buf[pos] == 0xFF)
+    {
+        pos++;
+        for (; pos < buf.size(); pos++)
+            p.payload.push_back(buf[pos]);
+    }
+
+    p.valid = true;
+    return p;
+}
+
+// Append a single option (with extended delta/length encoding) to a buffer.
+// Used by tests to craft incoming datagrams for Coap::loop().
+inline void coapAppendOption(std::vector<uint8_t> &buf, uint16_t number,
+                             uint16_t &running, const std::vector<uint8_t> &value)
+{
+    uint16_t delta = number - running;
+    uint16_t len = (uint16_t)value.size();
+
+    uint8_t deltaNibble, lenNibble;
+    std::vector<uint8_t> ext;
+
+    if (delta < 13)
+        deltaNibble = (uint8_t)delta;
+    else if (delta < 269)
+    {
+        deltaNibble = 13;
+        ext.push_back((uint8_t)(delta - 13));
+    }
+    else
+    {
+        deltaNibble = 14;
+        ext.push_back((uint8_t)((delta - 269) >> 8));
+        ext.push_back((uint8_t)((delta - 269) & 0xFF));
+    }
+
+    std::vector<uint8_t> lenExt;
+    if (len < 13)
+        lenNibble = (uint8_t)len;
+    else if (len < 269)
+    {
+        lenNibble = 13;
+        lenExt.push_back((uint8_t)(len - 13));
+    }
+    else
+    {
+        lenNibble = 14;
+        lenExt.push_back((uint8_t)((len - 269) >> 8));
+        lenExt.push_back((uint8_t)((len - 269) & 0xFF));
+    }
+
+    buf.push_back((deltaNibble << 4) | lenNibble);
+    for (uint8_t b : ext)
+        buf.push_back(b);
+    for (uint8_t b : lenExt)
+        buf.push_back(b);
+    for (uint8_t b : value)
+        buf.push_back(b);
+
+    running = number;
+}
+
+// Build a minimal CoAP request datagram with the given URI path segments.
+inline std::vector<uint8_t> coapBuildRequest(uint8_t type, uint8_t code,
+                                             uint16_t messageid,
+                                             const std::vector<std::string> &pathSegments,
+                                             const std::vector<uint8_t> &token = {},
+                                             const std::string &payload = "",
+                                             bool observe = false,
+                                             uint8_t observeValue = 0)
+{
+    std::vector<uint8_t> buf;
+    buf.push_back((0x01 << 6) | ((type & 0x03) << 4) | (token.size() & 0x0F));
+    buf.push_back(code);
+    buf.push_back((messageid >> 8) & 0xFF);
+    buf.push_back(messageid & 0xFF);
+    for (uint8_t b : token)
+        buf.push_back(b);
+
+    uint16_t running = 0;
+    if (observe)
+    {
+        std::vector<uint8_t> ov;
+        if (observeValue != 0)
+            ov.push_back(observeValue);
+        coapAppendOption(buf, 6 /* COAP_OBSERVE */, running, ov);
+    }
+    for (const auto &seg : pathSegments)
+    {
+        std::vector<uint8_t> v(seg.begin(), seg.end());
+        coapAppendOption(buf, 11 /* COAP_URI_PATH */, running, v);
+    }
+
+    if (!payload.empty())
+    {
+        buf.push_back(0xFF);
+        for (char c : payload)
+            buf.push_back((uint8_t)c);
+    }
+    return buf;
+}
+
+// Build a CoAP ACK datagram (the kind a server sends back to a client request),
+// used to drive the client-side response callback path through Coap::loop().
+inline std::vector<uint8_t> coapBuildAck(uint8_t code, uint16_t messageid,
+                                         const std::string &payload = "",
+                                         const std::vector<uint8_t> &token = {})
+{
+    std::vector<uint8_t> buf;
+    buf.push_back((0x01 << 6) | ((2 /* COAP_ACK */ & 0x03) << 4) | (token.size() & 0x0F));
+    buf.push_back(code);
+    buf.push_back((messageid >> 8) & 0xFF);
+    buf.push_back(messageid & 0xFF);
+    for (uint8_t b : token)
+        buf.push_back(b);
+    if (!payload.empty())
+    {
+        buf.push_back(0xFF);
+        for (char c : payload)
+            buf.push_back((uint8_t)c);
+    }
+    return buf;
+}
+
+#endif

--- a/test/FakeUDP.h
+++ b/test/FakeUDP.h
@@ -1,0 +1,117 @@
+// Test double for the Arduino UDP interface.
+//
+// FakeUDP records every datagram the library "sends" (so tests can inspect the
+// exact bytes on the wire) and lets tests queue up datagrams to be "received"
+// by Coap::loop().
+#ifndef __FAKE_UDP_H__
+#define __FAKE_UDP_H__
+
+#include "Udp.h"
+#include <vector>
+
+struct SentDatagram
+{
+    IPAddress ip;
+    uint16_t port;
+    std::vector<uint8_t> data;
+};
+
+struct IncomingDatagram
+{
+    std::vector<uint8_t> data;
+    IPAddress ip;
+    uint16_t port;
+};
+
+class FakeUDP : public UDP
+{
+public:
+    // Captured outgoing datagrams (one entry per endPacket()).
+    std::vector<SentDatagram> sent;
+
+    // Queue of datagrams that loop() will read via parsePacket()/read().
+    std::vector<IncomingDatagram> incoming;
+
+    uint16_t begin_port = 0;
+    bool begin_called = false;
+
+    // -- Outgoing path -----------------------------------------------------
+    uint8_t begin(uint16_t port) override
+    {
+        begin_called = true;
+        begin_port = port;
+        return 1;
+    }
+
+    int beginPacket(IPAddress ip, uint16_t port) override
+    {
+        _pending_ip = ip;
+        _pending_port = port;
+        _pending_data.clear();
+        return 1;
+    }
+
+    size_t write(const uint8_t *buffer, size_t size) override
+    {
+        for (size_t i = 0; i < size; i++)
+            _pending_data.push_back(buffer[i]);
+        return size;
+    }
+
+    int endPacket() override
+    {
+        SentDatagram d;
+        d.ip = _pending_ip;
+        d.port = _pending_port;
+        d.data = _pending_data;
+        sent.push_back(d);
+        return 1;
+    }
+
+    // -- Incoming path -----------------------------------------------------
+    void pushIncoming(const std::vector<uint8_t> &data, IPAddress ip, uint16_t port)
+    {
+        IncomingDatagram d;
+        d.data = data;
+        d.ip = ip;
+        d.port = port;
+        incoming.push_back(d);
+    }
+
+    int parsePacket() override
+    {
+        if (_in_idx < incoming.size())
+        {
+            _current = incoming[_in_idx++];
+            return (int)_current.data.size();
+        }
+        return 0;
+    }
+
+    int read(unsigned char *buffer, size_t len) override
+    {
+        size_t n = len < _current.data.size() ? len : _current.data.size();
+        memcpy(buffer, _current.data.data(), n);
+        return (int)n;
+    }
+
+    IPAddress remoteIP() override { return _current.ip; }
+    uint16_t remotePort() override { return _current.port; }
+
+    void reset()
+    {
+        sent.clear();
+        incoming.clear();
+        _in_idx = 0;
+    }
+
+private:
+    IPAddress _pending_ip;
+    uint16_t _pending_port = 0;
+    std::vector<uint8_t> _pending_data;
+
+    size_t _in_idx = 0;
+    IncomingDatagram _current;
+};
+
+#endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,28 @@
+# Build and run the host-side unit tests for coap-simple.
+#
+# Usage:
+#   make            # build the test runner
+#   make test       # build and run
+#   make clean
+
+CXX      ?= g++
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -g
+ROOT     := ..
+
+# mocks/ provides Arduino.h and Udp.h; ROOT provides coap-simple.h.
+INCLUDES := -I mocks -I . -I $(ROOT)
+
+SOURCES  := test_main.cpp test_examples.cpp $(ROOT)/coap-simple.cpp
+HEADERS  := mocks/Arduino.h mocks/Udp.h FakeUDP.h CoapCodec.h TestHarness.h
+TARGET   := runner
+
+$(TARGET): $(SOURCES) $(HEADERS)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SOURCES) -o $(TARGET)
+
+.PHONY: test
+test: $(TARGET)
+	./$(TARGET)
+
+.PHONY: clean
+clean:
+	rm -f $(TARGET)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,53 @@
+# Unit tests
+
+Host-side unit tests for the `coap-simple` library. They compile the real
+library (`../coap-simple.cpp`) against a small mocked Arduino environment, so
+no board or toolchain beyond a C++ compiler is required.
+
+## Running locally
+
+```sh
+cd test
+make test
+```
+
+This builds `runner` and executes it. The process exits non-zero if any check
+fails (which is what the CI uses to fail the build).
+
+## Layout
+
+| File | Purpose |
+| --- | --- |
+| `mocks/Arduino.h` | Minimal `String`, `IPAddress`, and a test-controllable `millis()`. |
+| `mocks/Udp.h` | The abstract `UDP` interface the library talks to. |
+| `FakeUDP.h` | UDP test double: captures sent datagrams, injects received ones. |
+| `CoapCodec.h` | Helpers to decode/encode CoAP datagrams for assertions. |
+| `TestHarness.h` | Shared assertion macros (`CHECK`, `CHECK_EQ`, `RUN`). |
+| `test_main.cpp` | Library unit tests + `main()`. |
+| `test_examples.cpp` | Integration tests mirroring `examples/` usage. |
+
+## Coverage
+
+**Library unit tests** (`test_main.cpp`) exercise packet/option encoding
+(`CoapPacket`), client requests (`get`/`put`/`send`, query parsing, tokens,
+content-format), response building (`sendResponse`, `sendObserveResponse`,
+observe uint encoding), incoming packet handling and dispatch (`loop`,
+NOT_FOUND, ACK/response callbacks, malformed input), and the Observe machinery
+(`addObserver`, `removeObserver`, `notify`, sequence numbering, lease expiry,
+capacity limits).
+
+**Example integration tests** (`test_examples.cpp`) reproduce the actual
+callbacks from `examples/` and drive a full request → callback → response
+round-trip through `loop()`:
+
+- the `light` endpoint (`coapserver`, `esp32`, `esp8266`): PUT `"1"`/`"0"`
+  toggles LED state and returns the new state; GET reports current state;
+- the client GET + `response()` callback flow (`coaptest`): a GET is emitted,
+  the server's ACK is fed back, and the response callback receives the payload;
+- multiple/nested endpoints (e.g. `env/temp`);
+- the Observe `subscribe` endpoint (`coapserver-with-observe`): plain GET,
+  register (Observe=0) + `notify()` delivery with token and sequence,
+  unsubscribe (Observe=1), and invalid Observe value → 4.02 Bad Option.
+
+Run automatically on pull requests to `master` via
+`.github/workflows/unit-tests.yml`.

--- a/test/TestHarness.h
+++ b/test/TestHarness.h
@@ -1,0 +1,45 @@
+// Tiny shared assertion harness for the coap-simple test suites.
+// Counters are defined once in test_main.cpp; every test source includes this.
+#ifndef __TEST_HARNESS_H__
+#define __TEST_HARNESS_H__
+
+#include <cstdio>
+
+extern int g_checks;
+extern int g_failures;
+extern const char *g_current_test;
+
+#define CHECK(cond)                                                       \
+    do                                                                    \
+    {                                                                     \
+        g_checks++;                                                       \
+        if (!(cond))                                                      \
+        {                                                                 \
+            g_failures++;                                                 \
+            printf("  FAIL [%s] %s:%d: %s\n", g_current_test, __FILE__,   \
+                   __LINE__, #cond);                                      \
+        }                                                                 \
+    } while (0)
+
+// Generic equality check (works for integers, std::string, std::vector, ...).
+#define CHECK_EQ(a, b)                                                       \
+    do                                                                       \
+    {                                                                        \
+        g_checks++;                                                          \
+        if (!((a) == (b)))                                                   \
+        {                                                                    \
+            g_failures++;                                                    \
+            printf("  FAIL [%s] %s:%d: %s == %s\n", g_current_test,          \
+                   __FILE__, __LINE__, #a, #b);                              \
+        }                                                                    \
+    } while (0)
+
+#define RUN(fn)                \
+    do                         \
+    {                          \
+        g_current_test = #fn;  \
+        printf("- %s\n", #fn); \
+        fn();                  \
+    } while (0)
+
+#endif

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -1,0 +1,94 @@
+// Minimal Arduino.h mock for host-side unit testing of coap-simple.
+// Provides just enough of the Arduino core API (String, IPAddress, millis,
+// and the standard C helpers the library relies on) to compile and run the
+// library off-device.
+#ifndef __ARDUINO_MOCK_H__
+#define __ARDUINO_MOCK_H__
+
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// millis() — backed by a test-controllable clock.
+// ---------------------------------------------------------------------------
+extern unsigned long __mock_millis_value;
+inline unsigned long millis() { return __mock_millis_value; }
+inline void setMillis(unsigned long v) { __mock_millis_value = v; }
+
+// ---------------------------------------------------------------------------
+// String — thin wrapper around std::string covering the methods coap-simple
+// uses (construction, assignment, +=, equals, length).
+// ---------------------------------------------------------------------------
+class String
+{
+public:
+    std::string s;
+
+    String() : s() {}
+    String(const char *c) : s(c ? c : "") {}
+    String(const String &o) : s(o.s) {}
+
+    String &operator=(const char *c)
+    {
+        s = c ? c : "";
+        return *this;
+    }
+    String &operator=(const String &o)
+    {
+        s = o.s;
+        return *this;
+    }
+
+    String &operator+=(const char *c)
+    {
+        if (c)
+            s += c;
+        return *this;
+    }
+    String &operator+=(const String &o)
+    {
+        s += o.s;
+        return *this;
+    }
+
+    bool equals(const String &o) const { return s == o.s; }
+    bool equals(const char *c) const { return s == (c ? c : ""); }
+
+    size_t length() const { return s.length(); }
+    const char *c_str() const { return s.c_str(); }
+};
+
+// ---------------------------------------------------------------------------
+// IPAddress — 4-octet IPv4 address with the [] and == operators the library
+// depends on.
+// ---------------------------------------------------------------------------
+class IPAddress
+{
+public:
+    uint8_t bytes[4];
+
+    IPAddress() { bytes[0] = bytes[1] = bytes[2] = bytes[3] = 0; }
+    IPAddress(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
+    {
+        bytes[0] = a;
+        bytes[1] = b;
+        bytes[2] = c;
+        bytes[3] = d;
+    }
+
+    uint8_t operator[](int index) const { return bytes[index]; }
+    uint8_t &operator[](int index) { return bytes[index]; }
+
+    bool operator==(const IPAddress &o) const
+    {
+        return bytes[0] == o.bytes[0] && bytes[1] == o.bytes[1] &&
+               bytes[2] == o.bytes[2] && bytes[3] == o.bytes[3];
+    }
+    bool operator!=(const IPAddress &o) const { return !(*this == o); }
+};
+
+#endif

--- a/test/mocks/Udp.h
+++ b/test/mocks/Udp.h
@@ -1,0 +1,24 @@
+// Minimal Udp.h mock for host-side unit testing of coap-simple.
+// Declares the abstract UDP interface coap-simple talks to. The concrete
+// test double lives in test/FakeUDP.h.
+#ifndef __UDP_MOCK_H__
+#define __UDP_MOCK_H__
+
+#include "Arduino.h"
+
+class UDP
+{
+public:
+    virtual ~UDP() {}
+
+    virtual uint8_t begin(uint16_t port) = 0;
+    virtual int beginPacket(IPAddress ip, uint16_t port) = 0;
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    virtual int endPacket() = 0;
+    virtual int parsePacket() = 0;
+    virtual int read(unsigned char *buffer, size_t len) = 0;
+    virtual IPAddress remoteIP() = 0;
+    virtual uint16_t remotePort() = 0;
+};
+
+#endif

--- a/test/test_examples.cpp
+++ b/test/test_examples.cpp
@@ -1,0 +1,361 @@
+// Integration tests that exercise the library the way the examples/ sketches do.
+//
+// Each example registers callbacks, calls coap.start(), and then in loop()
+// reacts to incoming datagrams. These tests reproduce those exact callbacks
+// (the LED "light" endpoint, the client response handler, and the Observe
+// "subscribe" endpoint) and drive a full request -> callback -> response
+// round-trip through Coap::loop() using the FakeUDP transport.
+#include "coap-simple.h"
+#include "FakeUDP.h"
+#include "CoapCodec.h"
+#include "TestHarness.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+// In the example sketches `coap` is a global object that the (function-pointer)
+// callbacks reach for. We mirror that with a global pointer set per test.
+static Coap *g_coap = nullptr;
+
+// CoAP option numbers used in assertions below.
+static const uint16_t OPT_OBSERVE = 6;
+static const uint16_t OPT_URI_PATH = 11;
+
+// --- examples/coapserver, esp32, esp8266: "light" endpoint + response handler ---
+
+// callback_light(), as in examples/coapserver/coapserver.ino.
+static bool g_ledState = true;
+
+static void callback_light(CoapPacket &packet, IPAddress ip, int port)
+{
+    char p[COAP_BUF_MAX_SIZE + 1];
+    memcpy(p, packet.payload, packet.payloadlen);
+    p[packet.payloadlen] = '\0';
+
+    String message(p);
+
+    if (message.equals("0"))
+        g_ledState = false;
+    else if (message.equals("1"))
+        g_ledState = true;
+
+    if (g_ledState)
+        g_coap->sendResponse(ip, port, packet.messageid, "1");
+    else
+        g_coap->sendResponse(ip, port, packet.messageid, "0");
+}
+
+// callback_response(): the example just reads and prints the payload.
+static std::string g_lastResponse;
+static int g_responseHits = 0;
+static void callback_response(CoapPacket &packet, IPAddress, int)
+{
+    char p[COAP_BUF_MAX_SIZE + 1];
+    memcpy(p, packet.payload, packet.payloadlen);
+    p[packet.payloadlen] = '\0';
+    g_lastResponse = p;
+    g_responseHits++;
+}
+
+// A remote coap-client doing `put coap://device/light -e "1"` should flip the
+// LED on and get "1" back; "0" flips it off and returns "0".
+static void test_example_light_put_toggles_led_and_responds()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+    g_ledState = true;
+
+    coap.server(callback_light, "light");
+    coap.start();
+
+    IPAddress client(192, 168, 0, 50);
+
+    // PUT "1"
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_PUT, 0x0101, {"light"}, {}, "1"),
+                     client, 40000);
+    coap.loop();
+    CHECK(g_ledState == true);
+    CHECK_EQ(udp.sent.size(), 1u);
+    {
+        DecodedPacket d = coapDecode(udp.sent[0].data);
+        CHECK(d.valid);
+        CHECK_EQ(d.type, (uint8_t)COAP_ACK);
+        CHECK_EQ(d.code, (uint8_t)COAP_CONTENT);
+        CHECK_EQ(d.messageid, 0x0101);
+        CHECK_EQ(d.payloadStr(), "1");
+        CHECK(udp.sent[0].ip == client);
+        CHECK_EQ(udp.sent[0].port, 40000);
+    }
+
+    // PUT "0"
+    udp.reset();
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_PUT, 0x0102, {"light"}, {}, "0"),
+                     client, 40000);
+    coap.loop();
+    CHECK(g_ledState == false);
+    {
+        DecodedPacket d = coapDecode(udp.sent[0].data);
+        CHECK_EQ(d.payloadStr(), "0");
+        CHECK_EQ(d.messageid, 0x0102);
+    }
+}
+
+// A GET on /light (no payload) should report the current LED state.
+static void test_example_light_get_reports_state()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+    g_ledState = true;
+
+    coap.server(callback_light, "light");
+    coap.start();
+
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 0x0200, {"light"}),
+                     IPAddress(10, 0, 0, 9), 5683);
+    coap.loop();
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.payloadStr(), "1");
+}
+
+// examples/coaptest: the client sends a GET, then the server's ACK comes back
+// and the registered response callback receives the payload.
+static void test_example_client_get_then_response_callback()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+    g_lastResponse = "";
+    g_responseHits = 0;
+
+    coap.response(callback_response);
+    coap.start();
+
+    // Client side: coap.get(ip, 5683, "time")
+    uint16_t mid = coap.get(IPAddress(10, 0, 0, 1), 5683, "time");
+    CHECK_EQ(udp.sent.size(), 1u);
+    DecodedPacket req = coapDecode(udp.sent[0].data);
+    CHECK_EQ(req.code, (uint8_t)COAP_GET);
+    CHECK_EQ(req.optionString(OPT_URI_PATH), "time");
+
+    // Server replies with an ACK 2.05 carrying the time; loop() routes ACKs to
+    // the response callback.
+    udp.pushIncoming(coapBuildAck((uint8_t)COAP_CONTENT, mid, "12:00"),
+                     IPAddress(10, 0, 0, 1), 5683);
+    coap.loop();
+
+    CHECK_EQ(g_responseHits, 1);
+    CHECK_EQ(g_lastResponse, "12:00");
+}
+
+// The example comments document registering several endpoints, including
+// nested ones like "env/temp". Verify multi-endpoint dispatch works.
+static int g_tempHits = 0;
+static void callback_temp(CoapPacket &packet, IPAddress ip, int port)
+{
+    g_tempHits++;
+    g_coap->sendResponse(ip, port, packet.messageid, "23");
+}
+static void test_example_multiple_endpoints()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+    g_ledState = true;
+    g_tempHits = 0;
+
+    coap.server(callback_light, "light");
+    coap.server(callback_temp, "env/temp");
+    coap.start();
+
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 1, {"env", "temp"}),
+                     IPAddress(1, 2, 3, 4), 5683);
+    coap.loop();
+
+    CHECK_EQ(g_tempHits, 1);
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK_EQ(d.payloadStr(), "23");
+}
+
+// --- examples/coapserver-with-observe: the "subscribe" Observe endpoint ---
+
+// endpoint_subscribe(), as in the coapserver-with-observe sketch.
+static void endpoint_subscribe(CoapPacket &packet, IPAddress ip, int port)
+{
+    uint32_t observeValue = 0;
+    if (!packet.getObserveValue(observeValue))
+    {
+        // No (or invalid) Observe option: treat as a normal GET.
+        char payload[6];
+        snprintf(payload, sizeof(payload), "%u", 42);
+        int payload_len = strlen(payload);
+        g_coap->sendResponse(ip, port, packet.messageid, payload, payload_len,
+                             COAP_CONTENT, COAP_TEXT_PLAIN, packet.token, packet.tokenlen);
+        return;
+    }
+
+    if (observeValue == 0)
+    {
+        if (!g_coap->addObserver("subscribe", ip, port, packet.token, packet.tokenlen))
+        {
+            g_coap->sendResponse(ip, port, packet.messageid, "busy", strlen("busy"),
+                                 COAP_SERVICE_UNAVAILABLE, COAP_TEXT_PLAIN, packet.token, packet.tokenlen);
+            return;
+        }
+        g_coap->sendObserveResponse(ip, port, packet.messageid, "subscribed", strlen("subscribed"),
+                                    COAP_CONTENT, COAP_TEXT_PLAIN, packet.token, packet.tokenlen, 0);
+    }
+    else if (observeValue == 1)
+    {
+        g_coap->removeObserver("subscribe", ip, port, packet.token, packet.tokenlen);
+        g_coap->sendResponse(ip, port, packet.messageid, "unsubscribed", strlen("unsubscribed"),
+                             COAP_CONTENT, COAP_TEXT_PLAIN, packet.token, packet.tokenlen);
+    }
+    else
+    {
+        g_coap->sendResponse(ip, port, packet.messageid, "invalid", strlen("invalid"),
+                             COAP_BAD_OPTION, COAP_TEXT_PLAIN, packet.token, packet.tokenlen);
+    }
+}
+
+// A plain GET (no Observe option) returns the current value and echoes token.
+static void test_example_subscribe_plain_get()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+
+    coap.server(endpoint_subscribe, "subscribe");
+    coap.start();
+
+    std::vector<uint8_t> token = {0xA1, 0xB2};
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 0x3001, {"subscribe"}, token),
+                     IPAddress(7, 7, 7, 7), 5683);
+    coap.loop();
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.type, (uint8_t)COAP_ACK);
+    CHECK_EQ(d.code, (uint8_t)COAP_CONTENT);
+    CHECK_EQ(d.payloadStr(), "42");
+    CHECK_EQ(d.token, token); // token echoed
+    CHECK_EQ(d.optionCount(OPT_OBSERVE), 0); // plain GET, no observe option
+}
+
+// Observe=0 registers the observer and replies with an Observe response, after
+// which notify() reaches that observer with the right token and sequence.
+static void test_example_subscribe_register_and_notify()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+
+    coap.server(endpoint_subscribe, "subscribe");
+    coap.start();
+
+    IPAddress observer(7, 7, 7, 8);
+    std::vector<uint8_t> token = {0xC0, 0xDE};
+
+    // Subscribe (Observe option value 0).
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 0x3100, {"subscribe"}, token,
+                                      "", /*observe=*/true, /*observeValue=*/0),
+                     observer, 41000);
+    coap.loop();
+
+    CHECK_EQ(udp.sent.size(), 1u);
+    DecodedPacket reg = coapDecode(udp.sent[0].data);
+    CHECK(reg.valid);
+    CHECK_EQ(reg.code, (uint8_t)COAP_CONTENT);
+    CHECK_EQ(reg.payloadStr(), "subscribed");
+    CHECK(reg.option(OPT_OBSERVE) != nullptr);                 // observe response
+    CHECK_EQ(reg.option(OPT_OBSERVE)->value.size(), 0u);       // seq 0 -> empty
+    CHECK_EQ(reg.token, token);
+
+    // Now the application pushes a notification to all observers of "subscribe".
+    udp.reset();
+    int sent = coap.notify("subscribe", "42", 2, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, 1);
+    CHECK_EQ(udp.sent.size(), 1u);
+
+    DecodedPacket note = coapDecode(udp.sent[0].data);
+    CHECK(note.valid);
+    CHECK_EQ(note.type, (uint8_t)COAP_NONCON);   // notifications are non-confirmable
+    CHECK_EQ(note.code, (uint8_t)COAP_CONTENT);
+    CHECK_EQ(note.token, token);                 // delivered with subscriber's token
+    CHECK_EQ(note.payloadStr(), "42");
+    CHECK(note.option(OPT_OBSERVE)->value == std::vector<uint8_t>({1})); // first seq
+    CHECK(udp.sent[0].ip == observer);
+    CHECK_EQ(udp.sent[0].port, 41000);
+}
+
+// Observe=1 deregisters: the endpoint replies "unsubscribed" and subsequent
+// notify() reaches nobody.
+static void test_example_subscribe_then_unsubscribe()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+
+    coap.server(endpoint_subscribe, "subscribe");
+    coap.start();
+
+    IPAddress observer(7, 7, 7, 9);
+    std::vector<uint8_t> token = {0x01};
+
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 1, {"subscribe"}, token, "", true, 0),
+                     observer, 42000);
+    coap.loop();
+    CHECK_EQ(coap.notify("subscribe", "x", 1, COAP_TEXT_PLAIN), 1);
+
+    // Unsubscribe (Observe option value 1).
+    udp.reset();
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 2, {"subscribe"}, token, "", true, 1),
+                     observer, 42000);
+    coap.loop();
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK_EQ(d.payloadStr(), "unsubscribed");
+
+    // No observers left.
+    CHECK_EQ(coap.notify("subscribe", "x", 1, COAP_TEXT_PLAIN), 0);
+}
+
+// An out-of-range Observe value yields a 4.02 Bad Option, per the example.
+static void test_example_subscribe_invalid_observe_value()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    g_coap = &coap;
+
+    coap.server(endpoint_subscribe, "subscribe");
+    coap.start();
+
+    std::vector<uint8_t> token = {0x55};
+    udp.pushIncoming(coapBuildRequest(COAP_CON, COAP_GET, 9, {"subscribe"}, token, "", true, 2),
+                     IPAddress(7, 7, 7, 10), 5683);
+    coap.loop();
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK_EQ(d.code, (uint8_t)COAP_BAD_OPTION);
+    CHECK_EQ(d.payloadStr(), "invalid");
+}
+
+void runExampleTests()
+{
+    RUN(test_example_light_put_toggles_led_and_responds);
+    RUN(test_example_light_get_reports_state);
+    RUN(test_example_client_get_then_response_callback);
+    RUN(test_example_multiple_endpoints);
+    RUN(test_example_subscribe_plain_get);
+    RUN(test_example_subscribe_register_and_notify);
+    RUN(test_example_subscribe_then_unsubscribe);
+    RUN(test_example_subscribe_invalid_observe_value);
+}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,640 @@
+// Host-side unit tests for the coap-simple library.
+//
+// These tests compile the real library against a mocked Arduino environment
+// (see test/mocks) and a FakeUDP transport that captures outgoing datagrams
+// and injects incoming ones. No hardware is required.
+#include "coap-simple.h"
+#include "FakeUDP.h"
+#include "CoapCodec.h"
+#include "TestHarness.h"
+
+#include <cstdio>
+#include <vector>
+#include <string>
+
+// Definition of the test-controlled millis() clock declared in Arduino.h.
+unsigned long __mock_millis_value = 0;
+
+// Definitions of the shared harness counters declared in TestHarness.h.
+int g_checks = 0;
+int g_failures = 0;
+const char *g_current_test = "";
+
+// Example-driven integration tests live in test_examples.cpp.
+void runExampleTests();
+
+// Server/response callbacks are plain function pointers on this build, so they
+// report back to the tests through these globals.
+struct CallbackCapture
+{
+    int hits = 0;
+    IPAddress ip;
+    int port = 0;
+    uint8_t code = 0;
+    uint8_t type = 0;
+    std::string payload;
+    bool isObserve = false;
+    uint32_t observeValue = 0;
+    bool observeValid = false;
+};
+
+static CallbackCapture g_serverCb;
+static CallbackCapture g_serverCb2;
+static CallbackCapture g_respCb;
+
+static void recordInto(CallbackCapture &c, CoapPacket &packet, IPAddress ip, int port)
+{
+    c.hits++;
+    c.ip = ip;
+    c.port = port;
+    c.code = packet.code;
+    c.type = packet.type;
+    c.payload.assign((const char *)packet.payload, packet.payloadlen);
+    c.isObserve = packet.isObserve();
+    c.observeValid = packet.getObserveValue(c.observeValue);
+}
+
+static void serverCallback(CoapPacket &packet, IPAddress ip, int port)
+{
+    recordInto(g_serverCb, packet, ip, port);
+}
+static void serverCallback2(CoapPacket &packet, IPAddress ip, int port)
+{
+    recordInto(g_serverCb2, packet, ip, port);
+}
+static void responseCallback(CoapPacket &packet, IPAddress ip, int port)
+{
+    recordInto(g_respCb, packet, ip, port);
+}
+
+static void resetCaptures()
+{
+    g_serverCb = CallbackCapture();
+    g_serverCb2 = CallbackCapture();
+    g_respCb = CallbackCapture();
+}
+
+// Option numbers (mirrors COAP_OPTION_NUMBER without depending on enum scope).
+static const uint16_t OPT_URI_HOST = 3;
+static const uint16_t OPT_OBSERVE = 6;
+static const uint16_t OPT_URI_PATH = 11;
+static const uint16_t OPT_CONTENT_FORMAT = 12;
+static const uint16_t OPT_URI_QUERY = 15;
+
+// --- CoapPacket ---
+
+static void test_addOption_stores_fields()
+{
+    CoapPacket p;
+    uint8_t buf[3] = {1, 2, 3};
+    p.addOption(OPT_URI_PATH, 3, buf);
+    CHECK_EQ(p.optionnum, 1);
+    CHECK_EQ(p.options[0].number, OPT_URI_PATH);
+    CHECK_EQ(p.options[0].length, 3);
+    CHECK_EQ(p.options[0].buffer[2], 3);
+}
+
+static void test_addOption_respects_max()
+{
+    CoapPacket p;
+    uint8_t b = 0;
+    for (int i = 0; i < COAP_MAX_OPTION_NUM + 5; i++)
+        p.addOption(OPT_URI_PATH, 1, &b);
+    CHECK_EQ(p.optionnum, COAP_MAX_OPTION_NUM);
+}
+
+static void test_isObserve()
+{
+    CoapPacket p;
+    uint8_t b = 0;
+    CHECK(!p.isObserve());
+    p.addOption(OPT_CONTENT_FORMAT, 1, &b);
+    CHECK(!p.isObserve());
+    p.addOption(OPT_OBSERVE, 0, &b);
+    CHECK(p.isObserve());
+}
+
+static void test_getObserveValue()
+{
+    CoapPacket p;
+    uint32_t v = 123;
+
+    // No observe option -> false, value untouched semantics not relied upon.
+    CHECK(!p.getObserveValue(v));
+
+    uint8_t empty = 0;
+    p.addOption(OPT_OBSERVE, 0, &empty); // zero-length -> value 0
+    v = 999;
+    CHECK(p.getObserveValue(v));
+    CHECK_EQ(v, 0);
+
+    CoapPacket p2;
+    uint8_t three[3] = {0x01, 0x02, 0x03};
+    p2.addOption(OPT_OBSERVE, 3, three);
+    CHECK(p2.getObserveValue(v));
+    CHECK_EQ(v, 0x010203u);
+
+    // length > 3 is invalid for the observe option.
+    CoapPacket p3;
+    uint8_t four[4] = {1, 2, 3, 4};
+    p3.addOption(OPT_OBSERVE, 4, four);
+    CHECK(!p3.getObserveValue(v));
+}
+
+// --- Client requests: get / put / send ---
+
+static void test_get_builds_con_get()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+    CHECK(udp.begin_called);
+    CHECK_EQ(udp.begin_port, COAP_DEFAULT_PORT);
+
+    uint16_t mid = coap.get(IPAddress(192, 168, 1, 1), 5683, "hello");
+    CHECK_EQ(udp.sent.size(), 1u);
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.version, 1);
+    CHECK_EQ(d.type, (uint8_t)COAP_CON);
+    CHECK_EQ(d.code, (uint8_t)COAP_GET);
+    CHECK_EQ(d.messageid, mid);
+    CHECK_EQ(d.tokenlen, 0);
+    CHECK_EQ(d.optionString(OPT_URI_HOST), "192.168.1.1");
+    CHECK_EQ(d.optionString(OPT_URI_PATH), "hello");
+    CHECK_EQ(d.optionCount(OPT_CONTENT_FORMAT), 0); // COAP_NONE -> no content-format
+    CHECK_EQ(d.payload.size(), 0u);
+    CHECK_EQ(udp.sent[0].port, 5683);
+}
+
+static void test_put_builds_payload()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.put(IPAddress(10, 0, 0, 5), 5683, "res", "value");
+    CHECK_EQ(udp.sent.size(), 1u);
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.type, (uint8_t)COAP_CON);
+    CHECK_EQ(d.code, (uint8_t)COAP_PUT);
+    CHECK_EQ(d.optionString(OPT_URI_PATH), "res");
+    CHECK_EQ(d.payloadStr(), "value");
+}
+
+static void test_send_with_content_format()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.send(IPAddress(1, 2, 3, 4), 5683, "x", COAP_CON, COAP_POST, NULL, 0,
+              (const uint8_t *)"hi", 2, COAP_APPLICATION_JSON, 0x1234);
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.messageid, 0x1234);
+    CHECK_EQ(d.code, (uint8_t)COAP_POST);
+    const DecodedOption *cf = d.option(OPT_CONTENT_FORMAT);
+    CHECK(cf != nullptr);
+    CHECK_EQ(cf->value.size(), 2u);
+    uint16_t cfval = (cf->value[0] << 8) | cf->value[1];
+    CHECK_EQ(cfval, (uint16_t)COAP_APPLICATION_JSON);
+}
+
+static void test_send_with_token()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    uint8_t token[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+    coap.send(IPAddress(1, 2, 3, 4), 5683, "a", COAP_CON, COAP_GET, token, 4,
+              NULL, 0, COAP_NONE, 0x4321);
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.tokenlen, 4);
+    CHECK_EQ(d.token.size(), 4u);
+    CHECK(d.token == std::vector<uint8_t>({0xDE, 0xAD, 0xBE, 0xEF}));
+}
+
+static void test_query_parsing()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.send(IPAddress(1, 2, 3, 4), 5683, "path?x=1&y=2", COAP_CON, COAP_GET,
+              NULL, 0, NULL, 0, COAP_NONE, 1);
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.optionString(OPT_URI_PATH), "path");
+    CHECK_EQ(d.optionCount(OPT_URI_QUERY), 2);
+    CHECK_EQ(d.options[2].str(),
+             "x=1");
+    CHECK_EQ(d.options[3].str(),
+             "y=2");
+}
+
+static void test_multi_segment_path()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.get(IPAddress(1, 2, 3, 4), 5683, "a/b/c");
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.optionCount(OPT_URI_PATH), 3);
+    CHECK_EQ(d.options[1].str(), "a");
+    CHECK_EQ(d.options[2].str(), "b");
+    CHECK_EQ(d.options[3].str(), "c");
+}
+
+// --- Responses ---
+
+static void test_sendResponse_basic()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.sendResponse(IPAddress(1, 2, 3, 4), 5683, 0xABCD, "ok");
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.type, (uint8_t)COAP_ACK);
+    CHECK_EQ(d.code, (uint8_t)COAP_CONTENT);
+    CHECK_EQ(d.messageid, 0xABCD);
+    CHECK_EQ(d.payloadStr(), "ok");
+    CHECK(d.option(OPT_CONTENT_FORMAT) != nullptr);
+}
+
+static void test_sendObserveResponse_includes_observe()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    uint8_t token[2] = {0xAA, 0xBB};
+    coap.sendObserveResponse(IPAddress(1, 2, 3, 4), 5683, 0x1111, "data", 4,
+                             COAP_CONTENT, COAP_TEXT_PLAIN, token, 2, 300);
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.type, (uint8_t)COAP_ACK);
+    CHECK_EQ(d.tokenlen, 2);
+    const DecodedOption *obs = d.option(OPT_OBSERVE);
+    CHECK(obs != nullptr);
+    // 300 needs two bytes: 0x01 0x2C
+    CHECK_EQ(obs->value.size(), 2u);
+    uint32_t val = 0;
+    for (uint8_t b : obs->value)
+        val = (val << 8) | b;
+    CHECK_EQ(val, 300u);
+}
+
+static void test_observe_uint_encoding_lengths()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    struct
+    {
+        uint32_t seq;
+        size_t len;
+    } cases[] = {{0, 0}, {1, 1}, {255, 1}, {256, 2}, {65535, 2}, {65536, 3}};
+
+    for (auto &c : cases)
+    {
+        udp.reset();
+        coap.sendObserveResponse(IPAddress(1, 2, 3, 4), 5683, 1, NULL, 0,
+                                 COAP_CONTENT, COAP_TEXT_PLAIN, NULL, 0, c.seq);
+        DecodedPacket d = coapDecode(udp.sent[0].data);
+        const DecodedOption *obs = d.option(OPT_OBSERVE);
+        CHECK(obs != nullptr);
+        CHECK_EQ(obs->value.size(), c.len);
+    }
+}
+
+// --- loop() dispatch ---
+
+static void test_loop_dispatches_to_server()
+{
+    resetCaptures();
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.server(serverCallback, "hello");
+    coap.start();
+
+    auto pkt = coapBuildRequest(COAP_NONCON, COAP_GET, 0x2020, {"hello"});
+    udp.pushIncoming(pkt, IPAddress(9, 8, 7, 6), 1234);
+    coap.loop();
+
+    CHECK_EQ(g_serverCb.hits, 1);
+    CHECK_EQ(g_serverCb.code, (uint8_t)COAP_GET);
+    CHECK_EQ(g_serverCb.port, 1234);
+    CHECK(g_serverCb.ip == IPAddress(9, 8, 7, 6));
+}
+
+static void test_loop_multi_segment_url()
+{
+    resetCaptures();
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.server(serverCallback2, "a/b");
+    coap.start();
+
+    auto pkt = coapBuildRequest(COAP_NONCON, COAP_GET, 1, {"a", "b"});
+    udp.pushIncoming(pkt, IPAddress(1, 1, 1, 1), 5683);
+    coap.loop();
+
+    CHECK_EQ(g_serverCb2.hits, 1);
+}
+
+static void test_loop_unknown_url_sends_not_found()
+{
+    resetCaptures();
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.server(serverCallback, "known");
+    coap.start();
+
+    auto pkt = coapBuildRequest(COAP_NONCON, COAP_GET, 0x7777, {"missing"});
+    udp.pushIncoming(pkt, IPAddress(2, 2, 2, 2), 5683);
+    coap.loop();
+
+    CHECK_EQ(g_serverCb.hits, 0);
+    CHECK_EQ(udp.sent.size(), 1u);
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.code, (uint8_t)COAP_NOT_FOUND);
+    CHECK_EQ(d.messageid, 0x7777);
+}
+
+static void test_loop_ack_calls_response()
+{
+    resetCaptures();
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.response(responseCallback);
+    coap.start();
+
+    udp.pushIncoming(coapBuildAck((uint8_t)COAP_CONTENT, 0x1234, "pong"),
+                     IPAddress(5, 5, 5, 5), 5683);
+    coap.loop();
+
+    CHECK_EQ(g_respCb.hits, 1);
+    CHECK_EQ(g_respCb.code, (uint8_t)COAP_CONTENT);
+    CHECK_EQ(g_respCb.payload, "pong");
+}
+
+static void test_loop_observe_request_flags()
+{
+    resetCaptures();
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.server(serverCallback, "temp");
+    coap.start();
+
+    auto pkt = coapBuildRequest(COAP_NONCON, COAP_GET, 1, {"temp"}, {},
+                                "", /*observe=*/true, /*observeValue=*/0);
+    udp.pushIncoming(pkt, IPAddress(3, 3, 3, 3), 5683);
+    coap.loop();
+
+    CHECK_EQ(g_serverCb.hits, 1);
+    CHECK(g_serverCb.isObserve);
+    CHECK(g_serverCb.observeValid);
+    CHECK_EQ(g_serverCb.observeValue, 0u);
+}
+
+static void test_loop_ignores_malformed()
+{
+    resetCaptures();
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.server(serverCallback, "hello");
+    coap.start();
+
+    // Too short / wrong version.
+    udp.pushIncoming({0x00, 0x01}, IPAddress(1, 1, 1, 1), 5683);
+    coap.loop();
+    CHECK_EQ(g_serverCb.hits, 0);
+    CHECK_EQ(udp.sent.size(), 0u);
+}
+
+// --- Observers and notify ---
+
+static void test_addObserver_and_notify()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    uint8_t token[2] = {0x01, 0x02};
+    CHECK(coap.addObserver("sensor", IPAddress(4, 4, 4, 4), 5683, token, 2));
+
+    int sent = coap.notify("sensor", "21C", 3, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, 1);
+    CHECK_EQ(udp.sent.size(), 1u);
+
+    DecodedPacket d = coapDecode(udp.sent[0].data);
+    CHECK(d.valid);
+    CHECK_EQ(d.type, (uint8_t)COAP_NONCON);
+    CHECK_EQ(d.code, (uint8_t)COAP_CONTENT);
+    CHECK_EQ(d.tokenlen, 2);
+    CHECK_EQ(d.payloadStr(), "21C");
+    const DecodedOption *obs = d.option(OPT_OBSERVE);
+    CHECK(obs != nullptr);
+    CHECK(obs->value == std::vector<uint8_t>({1})); // first notification -> seq 1
+}
+
+static void test_notify_increments_sequence()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.addObserver("s", IPAddress(4, 4, 4, 4), 5683, NULL, 0);
+    coap.notify("s", "a", 1, COAP_TEXT_PLAIN);
+    coap.notify("s", "b", 1, COAP_TEXT_PLAIN);
+    CHECK_EQ(udp.sent.size(), 2u);
+
+    DecodedPacket d1 = coapDecode(udp.sent[0].data);
+    DecodedPacket d2 = coapDecode(udp.sent[1].data);
+    CHECK(d1.option(OPT_OBSERVE)->value == std::vector<uint8_t>({1}));
+    CHECK(d2.option(OPT_OBSERVE)->value == std::vector<uint8_t>({2}));
+}
+
+static void test_addObserver_dedup()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    uint8_t token[1] = {0x09};
+    CHECK(coap.addObserver("d", IPAddress(4, 4, 4, 4), 5683, token, 1));
+    CHECK(coap.addObserver("d", IPAddress(4, 4, 4, 4), 5683, token, 1)); // duplicate
+
+    int sent = coap.notify("d", "x", 1, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, 1); // only one observer registered
+}
+
+static void test_addObserver_capacity()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    for (int i = 0; i < COAP_MAX_OBSERVERS; i++)
+    {
+        uint8_t token[1] = {(uint8_t)i};
+        CHECK(coap.addObserver("c", IPAddress(4, 4, 4, 4), 5683, token, 1));
+    }
+    uint8_t extra[1] = {0xFF};
+    CHECK(!coap.addObserver("c", IPAddress(4, 4, 4, 4), 5683, extra, 1));
+
+    int sent = coap.notify("c", "x", 1, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, COAP_MAX_OBSERVERS);
+}
+
+static void test_removeObserver()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    uint8_t token[1] = {0x07};
+    coap.addObserver("r", IPAddress(4, 4, 4, 4), 5683, token, 1);
+    CHECK(coap.removeObserver("r", IPAddress(4, 4, 4, 4), 5683, token, 1));
+
+    int sent = coap.notify("r", "x", 1, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, 0);
+
+    // Removing again returns false.
+    CHECK(!coap.removeObserver("r", IPAddress(4, 4, 4, 4), 5683, token, 1));
+}
+
+static void test_addObserver_rejects_invalid()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    // URL too long.
+    std::string longUrl(COAP_MAX_OBSERVE_URL_LEN + 1, 'a');
+    CHECK(!coap.addObserver(longUrl.c_str(), IPAddress(4, 4, 4, 4), 5683, NULL, 0));
+
+    // Token too long.
+    uint8_t token[9] = {0};
+    CHECK(!coap.addObserver("ok", IPAddress(4, 4, 4, 4), 5683, token, 9));
+
+    // Null URL.
+    CHECK(!coap.addObserver(NULL, IPAddress(4, 4, 4, 4), 5683, NULL, 0));
+}
+
+static void test_notify_lease_expiry()
+{
+    setMillis(1000);
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    coap.addObserver("lease", IPAddress(4, 4, 4, 4), 5683, NULL, 0);
+
+    // Advance the clock beyond the lease window.
+    setMillis(1000 + COAP_OBSERVER_LEASE_MS + 1);
+    int sent = coap.notify("lease", "x", 1, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, 0);
+    CHECK_EQ(udp.sent.size(), 0u);
+
+    // Observer should now be evicted, so a subsequent notify also sends nothing.
+    sent = coap.notify("lease", "x", 1, COAP_TEXT_PLAIN);
+    CHECK_EQ(sent, 0);
+}
+
+static void test_notify_observer_object()
+{
+    FakeUDP udp;
+    Coap coap(udp);
+    coap.start();
+
+    uint8_t token[3] = {0x11, 0x22, 0x33};
+    Observer obs(IPAddress(8, 8, 8, 8), 5683, token, 3);
+    coap.notify(&obs, "hi", 2, COAP_TEXT_PLAIN);
+    coap.notify(&obs, "hi", 2, COAP_TEXT_PLAIN);
+    CHECK_EQ(udp.sent.size(), 2u);
+
+    DecodedPacket d1 = coapDecode(udp.sent[0].data);
+    CHECK_EQ(d1.type, (uint8_t)COAP_NONCON);
+    CHECK_EQ(d1.tokenlen, 3);
+    CHECK(d1.option(OPT_OBSERVE)->value == std::vector<uint8_t>({1}));
+
+    DecodedPacket d2 = coapDecode(udp.sent[1].data);
+    CHECK(d2.option(OPT_OBSERVE)->value == std::vector<uint8_t>({2}));
+}
+
+static void test_observer_token_clamped()
+{
+    uint8_t token[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    Observer obs(IPAddress(1, 1, 1, 1), 5683, token, 10);
+    CHECK_EQ(obs.token_len, 8);
+}
+
+int main()
+{
+    printf("Running coap-simple unit tests\n\n");
+    printf("== Library unit tests ==\n");
+
+    // CoapPacket
+    RUN(test_addOption_stores_fields);
+    RUN(test_addOption_respects_max);
+    RUN(test_isObserve);
+    RUN(test_getObserveValue);
+
+    // Client requests
+    RUN(test_get_builds_con_get);
+    RUN(test_put_builds_payload);
+    RUN(test_send_with_content_format);
+    RUN(test_send_with_token);
+    RUN(test_query_parsing);
+    RUN(test_multi_segment_path);
+
+    // Responses
+    RUN(test_sendResponse_basic);
+    RUN(test_sendObserveResponse_includes_observe);
+    RUN(test_observe_uint_encoding_lengths);
+
+    // loop()
+    RUN(test_loop_dispatches_to_server);
+    RUN(test_loop_multi_segment_url);
+    RUN(test_loop_unknown_url_sends_not_found);
+    RUN(test_loop_ack_calls_response);
+    RUN(test_loop_observe_request_flags);
+    RUN(test_loop_ignores_malformed);
+
+    // Observers + notify
+    RUN(test_addObserver_and_notify);
+    RUN(test_notify_increments_sequence);
+    RUN(test_addObserver_dedup);
+    RUN(test_addObserver_capacity);
+    RUN(test_removeObserver);
+    RUN(test_addObserver_rejects_invalid);
+    RUN(test_notify_lease_expiry);
+    RUN(test_notify_observer_object);
+    RUN(test_observer_token_clamped);
+
+    // Integration tests that mirror how the examples/ sketches use the library.
+    printf("\n== Example usage integration tests ==\n");
+    runExampleTests();
+
+    printf("\n%d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
- Introduced a minimal test harness in TestHarness.h for shared assertions.
- Created Arduino.h mock to simulate Arduino core API for host-side testing.
- Added Udp.h mock to define the abstract UDP interface for testing.
- Implemented integration tests in test_examples.cpp to validate example usage of the library.
- Developed unit tests in test_main.cpp covering CoapPacket functionality, client requests, responses, loop dispatch, and observer behavior.